### PR TITLE
Refactor/performance optimization

### DIFF
--- a/models.py
+++ b/models.py
@@ -22,7 +22,7 @@ class FlightEvent(BaseModel):
         cls, arrival_datetime: datetime, info: ValidationInfo
     ):
         """Ensure arrival time is after departure time."""
-        departure_datetime = info.data["departure_datetime"]  # ✅ FIX: Use `info.data`
+        departure_datetime = info.data["departure_datetime"]
         if departure_datetime and arrival_datetime <= departure_datetime:
             raise ValueError("Arrival time must be after departure time.")
         return arrival_datetime

--- a/services.py
+++ b/services.py
@@ -1,12 +1,14 @@
-from httpx import AsyncClient, RequestError
 from asyncio import sleep
+from bisect import bisect_left, bisect_right
+from collections import defaultdict
+from datetime import datetime, timedelta
 from logging import getLogger, basicConfig, INFO
+from typing import List, Dict, Tuple, Set
+
+from httpx import AsyncClient, RequestError
 
 from exceptions import FlightDataFetchError
-from datetime import datetime, timedelta
-from typing import List, Dict
 from models import FlightEvent, Journey
-
 
 basicConfig(level=INFO)
 logger = getLogger(__name__)
@@ -49,113 +51,88 @@ async def fetch_flight_events() -> List[FlightEvent]:
 
 
 async def search_journeys(date: str, origin: str, destination: str) -> List[Journey]:
-    """
-    Searches for valid journeys (direct or with one connection) from an origin to a destination.
-
-    Args:
-        date (str): The travel date in 'YYYY-MM-DD' format.
-        origin (str): The IATA code of the departure city.
-        destination (str): The IATA code of the arrival city.
-
-    Returns:
-        List[Journey]: A list of valid journeys matching the criteria.
-    """
     all_flights = await fetch_flight_events()
     search_date = datetime.strptime(date, "%Y-%m-%d")
 
-    # Filter flights that operate on the requested date range
-    flights = filter_flights_by_date(all_flights, search_date)
-
-    # Build indexes for efficient lookups
-    flights_by_departure = build_flights_index_by_departure(flights)
-
-    # Early exit if there are no flights departing from origin or arriving at destination
-    if origin not in flights_by_departure:
-        logger.warning(f"No available flights departing from '{origin}'.")
-        return []
-    if destination not in [f.arrival_city for f in flights]:
-        logger.warning(f"No available flights arriving at '{destination}'.")
-        return []
-
-    # Retrieve direct and connecting journeys using the indexes
-    direct_flights = get_direct_flights(
-        flights_by_departure.get(origin, []), destination
-    )
-    connecting_flights = get_connecting_flights(
-        flights_by_departure, origin, destination
+    # Filter flights and track arrival cities in a set
+    flights, arrival_cities = filter_flights_by_date_and_track_arrivals(
+        all_flights, search_date
     )
 
-    valid_journeys = direct_flights + connecting_flights
-    if not valid_journeys:
-        logger.info(
-            f"No journeys available for the route {origin} → {destination} on {date}."
-        )
-    return valid_journeys
+    # Build nested index: departure → arrival → sorted flights (by departure time)
+    flights_index = build_nested_flights_index(flights)
 
+    # Early exit if origin/destination is invalid
+    if origin not in flights_index or destination not in arrival_cities:
+        return []
 
-def filter_flights_by_date(
-    flights: List[FlightEvent], search_date: datetime
-) -> List[FlightEvent]:
-    """
-    Filters flights that operate on the requested date (from midnight of search_date to before midnight the next day).
-    """
-    next_date = search_date + timedelta(days=1)
-    return [
-        flight
-        for flight in flights
-        if search_date.date() <= flight.departure_datetime.date() <= next_date.date()
+    # Find direct flights
+    direct_flights = flights_index.get(origin, {}).get(destination, [])
+    direct_journeys = [
+        Journey(connections=0, path=[flight])
+        for flight in direct_flights
+        if (flight.arrival_datetime - flight.departure_datetime) <= timedelta(hours=24)
     ]
 
+    # Find connecting flights efficiently
+    connecting_journeys = get_connecting_flights_optimized(
+        flights_index, origin, destination
+    )
 
-def build_flights_index_by_departure(
-    flights: List[FlightEvent],
-) -> Dict[str, List[FlightEvent]]:
-    """
-    Builds an index of flights keyed by departure city.
-    """
-    index = {}
+    return direct_journeys + connecting_journeys
+
+
+def filter_flights_by_date_and_track_arrivals(
+    flights: List[FlightEvent], search_date: datetime
+) -> Tuple[List[FlightEvent], Set[str]]:
+    next_date = search_date + timedelta(days=1)
+    filtered_flights = []
+    arrival_cities = set()
     for flight in flights:
-        index.setdefault(flight.departure_city, []).append(flight)
+        if search_date.date() <= flight.departure_datetime.date() <= next_date.date():
+            filtered_flights.append(flight)
+            arrival_cities.add(flight.arrival_city)
+    return filtered_flights, arrival_cities
+
+
+def build_nested_flights_index(
+    flights: List[FlightEvent],
+) -> Dict[str, Dict[str, List[FlightEvent]]]:
+    index = defaultdict(lambda: defaultdict(list))
+    for flight in flights:
+        # Sort flights by departure time for binary search later
+        index[flight.departure_city][flight.arrival_city].append(flight)
+    # Sort flights by departure time for each (departure, arrival) pair
+    for dep in index:
+        for arr in index[dep]:
+            index[dep][arr].sort(key=lambda f: f.departure_datetime)
     return index
 
 
-def get_direct_flights(
-    flights_from_origin: List[FlightEvent], destination: str
+def get_connecting_flights_optimized(
+    index: Dict[str, Dict[str, List[FlightEvent]]], origin: str, destination: str
 ) -> List[Journey]:
-    """
-    Extracts direct flights (without connection) from the given list of flights departing from the origin.
-    """
-    direct_journeys = []
-    for flight in flights_from_origin:
-        if flight.arrival_city == destination:
-            # Ensure the flight's duration is within 24 hours
-            if (flight.arrival_datetime - flight.departure_datetime) <= timedelta(
-                hours=24
-            ):
-                direct_journeys.append(Journey(connections=0, path=[flight]))
-    return direct_journeys
-
-
-def get_connecting_flights(
-    flights_by_departure: Dict[str, List[FlightEvent]], origin: str, destination: str
-) -> List[Journey]:
-    """
-    Extracts connecting flights (with one stop) that depart from the origin and arrive at the destination.
-    Uses the departure index for efficient lookup.
-    """
     connecting_journeys = []
-    # Iterate over flights departing from the origin
-    for flight1 in flights_by_departure.get(origin, []):
-        # For a valid connection, look up flights departing from flight1's arrival city
-        for flight2 in flights_by_departure.get(flight1.arrival_city, []):
-            if flight2.arrival_city == destination:
-                layover = flight2.departure_datetime - flight1.arrival_datetime
-                total_journey_time = (
-                    flight2.arrival_datetime - flight1.departure_datetime
-                )
-                if timedelta(hours=0) <= layover <= timedelta(
-                    hours=4
-                ) and total_journey_time <= timedelta(hours=24):
+    # Get all flights from origin
+    origin_flights = index.get(origin, {})
+    for arrival_city, flight1_list in origin_flights.items():
+        if arrival_city == destination:
+            continue  # Skip direct flights (already handled)
+        # Get flights from arrival_city to destination
+        flight2_list = index.get(arrival_city, {}).get(destination, [])
+        for flight1 in flight1_list:
+            # Find flight2s with valid layover (0–4 hours)
+            min_departure = flight1.arrival_datetime
+            max_departure = flight1.arrival_datetime + timedelta(hours=4)
+
+            # Extract departure times for binary search
+            departure_times = [f.departure_datetime for f in flight2_list]
+            left = bisect_left(departure_times, min_departure)
+            right = bisect_right(departure_times, max_departure)
+
+            for flight2 in flight2_list[left:right]:
+                total_time = flight2.arrival_datetime - flight1.departure_datetime
+                if total_time <= timedelta(hours=24):
                     connecting_journeys.append(
                         Journey(connections=1, path=[flight1, flight2])
                     )

--- a/services.py
+++ b/services.py
@@ -51,6 +51,15 @@ async def fetch_flight_events() -> List[FlightEvent]:
 
 
 async def search_journeys(date: str, origin: str, destination: str) -> List[Journey]:
+    """
+    Searches for valid journeys (direct or with one connection) from an origin to a destination.
+    Args:
+        date (str): The travel date in 'YYYY-MM-DD' format.
+        origin (str): The IATA code of the departure city.
+        destination (str): The IATA code of the arrival city.
+    Returns:
+        List[Journey]: A list of valid journeys matching the criteria.
+    """
     all_flights = await fetch_flight_events()
     search_date = datetime.strptime(date, "%Y-%m-%d")
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timedelta
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from main import app
+from unittest.mock import AsyncMock, patch
+from models import FlightEvent
+
+
+@pytest.fixture
+def client():
+    """Provides a FastAPI test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def huge_flight_dataset():
+    # Fixed reference date for deterministic testing
+    REF_DATE = datetime(2024, 1, 15, 0, 0)  # Arbitrary fixed date
+
+    def generate_flight(
+        flight_number, dep_city, arr_city, minutes_offset, duration_hours
+    ):
+        departure = REF_DATE + timedelta(minutes=minutes_offset)
+        return FlightEvent(
+            flight_number=flight_number,
+            departure_city=dep_city,
+            arrival_city=arr_city,
+            departure_datetime=departure.isoformat() + "Z",
+            arrival_datetime=(departure + timedelta(hours=duration_hours)).isoformat()
+            + "Z",
+        )
+
+    flights = []
+    ORIGIN = "ORG"
+    DESTINATION = "DST"
+    HUB = "HUB"
+
+    # Direct flights (all within valid date range)
+    for i in range(5000):
+        flights.append(
+            generate_flight(
+                flight_number=f"DIR{i}",
+                dep_city=ORIGIN,
+                arr_city=DESTINATION,
+                minutes_offset=i,  # Within same day
+                duration_hours=2,
+            )
+        )
+
+    # Connecting flights (valid layovers)
+    for i in range(10000):
+        # First leg
+        flights.append(
+            generate_flight(
+                flight_number=f"CONN_A{i}",
+                dep_city=ORIGIN,
+                arr_city=HUB,
+                minutes_offset=i,
+                duration_hours=2,
+            )
+        )
+        # Second leg (valid 2h10m layover)
+        flights.append(
+            generate_flight(
+                flight_number=f"CONN_B{i}",
+                dep_city=HUB,
+                arr_city=DESTINATION,
+                minutes_offset=i + 130,  # 2h10m after first flight arrives
+                duration_hours=1.5,
+            )
+        )
+
+    return {"flights": flights, "expected_direct": 2880, "expected_connecting": 636185}
+
+
+@patch("services.fetch_flight_events", new_callable=AsyncMock)
+def test_search_huge_dataset_performance(
+    mock_fetch_flight_events, client, huge_flight_dataset
+):
+    """
+    Test the performance of searching a huge dataset of flights. 639065 journeys are expected.
+    :param mock_fetch_flight_events:
+    :param client:
+    :param huge_flight_dataset:
+    :return:
+    [100%]Elapsed time: 15.605517 seconds for 639065 journeys
+    """
+    mock_fetch_flight_events.return_value = huge_flight_dataset["flights"]
+    test_date = "2024-01-15"  # Matches the fixed reference date
+    t0 = datetime.now()
+    response = client.get(
+        "/journeys/search", params={"date": test_date, "from": "ORG", "to": "DST"}
+    )
+    elapsed = (datetime.now() - t0).total_seconds()
+    assert response.status_code == 200
+    data = response.json()
+
+    direct_count = len([j for j in data if j["connections"] == 0])
+    connecting_count = len([j for j in data if j["connections"] == 1])
+    assert direct_count == huge_flight_dataset["expected_direct"]
+    assert connecting_count == huge_flight_dataset["expected_connecting"]
+    print(f"Elapsed time: {elapsed} seconds for {len(data)} journeys")

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -15,8 +15,7 @@ def client():
 
 @pytest.fixture
 def huge_flight_dataset():
-    # Fixed reference date for deterministic testing
-    REF_DATE = datetime(2024, 1, 15, 0, 0)  # Arbitrary fixed date
+    REF_DATE = datetime(2024, 1, 15, 0, 0)
 
     def generate_flight(
         flight_number, dep_city, arr_city, minutes_offset, duration_hours
@@ -36,21 +35,18 @@ def huge_flight_dataset():
     DESTINATION = "DST"
     HUB = "HUB"
 
-    # Direct flights (all within valid date range)
     for i in range(5000):
         flights.append(
             generate_flight(
                 flight_number=f"DIR{i}",
                 dep_city=ORIGIN,
                 arr_city=DESTINATION,
-                minutes_offset=i,  # Within same day
+                minutes_offset=i,
                 duration_hours=2,
             )
         )
 
-    # Connecting flights (valid layovers)
     for i in range(10000):
-        # First leg (ORG → HUB)
         flight_a = generate_flight(
             flight_number=f"CONN_A{i}",
             dep_city=ORIGIN,
@@ -59,12 +55,11 @@ def huge_flight_dataset():
             duration_hours=2,
         )
 
-        # Second leg (HUB → DST) with EXACTLY 2h10m layover
         flight_b = generate_flight(
             flight_number=f"CONN_B{i}",
             dep_city=HUB,
             arr_city=DESTINATION,
-            minutes_offset=i + 130,  # 2h10m after flight_a arrives
+            minutes_offset=i + 130,
             duration_hours=1.5,
         )
 
@@ -80,14 +75,9 @@ def test_search_huge_dataset_performance(
 ):
     """
     Test the performance of searching a huge dataset of flights. 639065 journeys are expected.
-    :param mock_fetch_flight_events:
-    :param client:
-    :param huge_flight_dataset:
-    :return:
-    [100%]Elapsed time: 15.605517 seconds for 639065 journeys
     """
     mock_fetch_flight_events.return_value = huge_flight_dataset["flights"]
-    test_date = "2024-01-15"  # Matches the fixed reference date
+    test_date = "2024-01-15"
     t0 = datetime.now()
     response = client.get(
         "/journeys/search", params={"date": test_date, "from": "ORG", "to": "DST"}

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -50,26 +50,25 @@ def huge_flight_dataset():
 
     # Connecting flights (valid layovers)
     for i in range(10000):
-        # First leg
-        flights.append(
-            generate_flight(
-                flight_number=f"CONN_A{i}",
-                dep_city=ORIGIN,
-                arr_city=HUB,
-                minutes_offset=i,
-                duration_hours=2,
-            )
+        # First leg (ORG → HUB)
+        flight_a = generate_flight(
+            flight_number=f"CONN_A{i}",
+            dep_city=ORIGIN,
+            arr_city=HUB,
+            minutes_offset=i,
+            duration_hours=2,
         )
-        # Second leg (valid 2h10m layover)
-        flights.append(
-            generate_flight(
-                flight_number=f"CONN_B{i}",
-                dep_city=HUB,
-                arr_city=DESTINATION,
-                minutes_offset=i + 130,  # 2h10m after first flight arrives
-                duration_hours=1.5,
-            )
+
+        # Second leg (HUB → DST) with EXACTLY 2h10m layover
+        flight_b = generate_flight(
+            flight_number=f"CONN_B{i}",
+            dep_city=HUB,
+            arr_city=DESTINATION,
+            minutes_offset=i + 130,  # 2h10m after flight_a arrives
+            duration_hours=1.5,
         )
+
+        flights.extend([flight_a, flight_b])
 
     return {"flights": flights, "expected_direct": 2880, "expected_connecting": 636185}
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -73,6 +73,7 @@ def huge_flight_dataset():
     return {"flights": flights, "expected_direct": 2880, "expected_connecting": 636185}
 
 
+@pytest.mark.skip(reason="Performance test; run manually when needed")
 @patch("services.fetch_flight_events", new_callable=AsyncMock)
 def test_search_huge_dataset_performance(
     mock_fetch_flight_events, client, huge_flight_dataset


### PR DESCRIPTION

Optimized Journey Search for Improved Performance
This PR introduces optimizations to the flight search logic, significantly reducing execution time while maintaining correctness. The primary improvements include:

Indexing flights efficiently: We now use a nested index (departure → arrival → sorted flights) to quickly access relevant flights.
Using bisect_left and bisect_right: Instead of iterating over all potential connections, we perform binary search to efficiently locate valid flights within the layover window.
Minimizing redundant checks: We track arrival cities using a set() and avoid unnecessary lookups for unreachable destinations.

Tested on a large dataset:

Before (main branch): Elapsed time: 25.294524 seconds for 639065 journeys
After (this PR): Elapsed time: 15.743839 seconds for 639065 journeys
Performance improvement: 🚀 ~37.7% faster

Testing
A performance test (test_search_huge_dataset_performance) has been added to measure execution time. Given its runtime, we are skipping it by default to avoid unnecessary execution in regular test runs.

To run the test manually, comment the line: 
@pytest.mark.skip(reason="Performance test; run manually when needed")

Then run: 
pytest -k test_search_huge_dataset_performance